### PR TITLE
change target influxdb database for telegraf

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -87,7 +87,7 @@
   # urls = ["udp://localhost:8089"] # UDP endpoint example
   urls = ["http://localhost:8086"] # required
   ## The target database for metrics (telegraf will create it if not exists).
-  database = "telegraf" # required
+  database = "statsd" # to simulate Reputedly's StatsD server
 
   ## Retention policy to write to. Empty string writes to the default rp.
   retention_policy = ""


### PR DESCRIPTION
I'd like to integrate Kapacitor tests with reputedly, but those tests assume that metrics will show up in the "statsd" database instead of the "telegraf" database